### PR TITLE
Improved error message for incorrect image name

### DIFF
--- a/master/app/code/Magento/GiftWrapping/i18n/nl_NL.csv
+++ b/master/app/code/Magento/GiftWrapping/i18n/nl_NL.csv
@@ -33,7 +33,7 @@
 "None","Geen"
 "The image content must be valid data.","De inhoud van de afbeelding heeft geen geldige gegevens."
 "The image extension ""%1"" not allowed.","De afbeelding extensie ""%1"" niet toegestaan."
-"Provided image name contains forbidden characters.","De opgegeven afbeelding bevat ongeldige tekens."
+"Provided image name contains forbidden characters.","De opgegeven afbeeldingsnaam bevat ongeldige tekens."
 "The image MIME type is not valid or not supported.","De afbeelding MIME type is niet geldig of wordt niet ondersteund."
 "Gift Wrapping with specified ID ""%1"" not found.","Kadoverpakking met de opgegeven ID ""%1"" is niet gevonden."
 "Please enter valid currency code: %1","Geef een geldige valutacode: %1"


### PR DESCRIPTION
I've stumbled upon this message and checking the image over and over. But after searching for the translations the error was for the name I have given it.